### PR TITLE
Add GitHub templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Description
+
+<!--- Please describe what this PR is going to change -->
+
+## Why is this needed
+
+<!--- Link to issue you have raised -->
+
+Fixes: #
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+
+## How are existing users impacted? What migration steps/scripts do we need?
+
+<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
+<!--- Requires a DB migration script, etc. -->
+
+
+## Checklist:
+
+I have:
+
+- [ ] updated the documentation and/or roadmap (if required)
+- [ ] added unit or e2e tests
+- [ ] provided instructions on how to upgrade

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Description
+
+<!--- Please describe what this PR is going to change -->
+
+## Why is this needed
+
+<!--- Link to issue you have raised -->
+
+Fixes: #
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+
+## How are existing users impacted? What migration steps/scripts do we need?
+
+<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
+<!--- Requires a DB migration script, etc. -->
+
+
+## Checklist:
+
+I have:
+
+- [ ] updated the documentation and/or roadmap (if required)
+- [ ] added unit or e2e tests
+- [ ] provided instructions on how to upgrade


### PR DESCRIPTION
These GitHub templates aim to improve the level of detail on
pull requests and issues raised by the team, to make the
external community feel more welcome and part of the project.

These are copyright to OpenFaaS Ltd, but we are happy to
contribute them under the license of this project for use by
Packet / Tinkerbell.

## Other considerations

This PR also closes a PR raised on the tink repo

Closes: https://github.com/tinkerbell/tink/pull/185

Whilst it is useful to have a global template, individual
templates should still be used in specific repos to gather
diagnostic information and to ask the right questions about
PRs.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>