### PR TITLE
GitHub as code with Terraform

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -3,7 +3,6 @@ name: "Terraform"
 on:
   push:
   pull_request:
-    types: [labeled]
   paths:
     - 'terraform/**'
 
@@ -69,8 +68,8 @@ jobs:
         working-directory: ./terrraform
         if: contains(github.event.pull_request.labels.*.name, 'ci-check/terraform') && steps.plan.outcome == 'failure'
         run: exit 1
-
-      - name: Terraform Apply
-        working-directory: ./terrraform
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        run: terraform apply -auto-approve
+      # We will introduce it as soon as we validate a few PR and see what plan has to say!
+      #- name: Terraform Apply
+        #working-directory: ./terrraform
+        #if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        #run: terraform apply -auto-approve

--- a/terraform/.github/workflows/terraform.yaml
+++ b/terraform/.github/workflows/terraform.yaml
@@ -1,0 +1,76 @@
+name: "Terraform"
+
+on:
+  push:
+  pull_request:
+    types: [labeled]
+  paths:
+    - 'terraform/**'
+
+jobs:
+  terraform:
+    name: "Terraform"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Terraform Format
+        id: fmt
+        working-directory: ./terrraform
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        if: contains(github.event.pull_request.labels.*.name, 'ci-check/terraform') && github.event_name == 'pull_request'
+        id: init
+        working-directory: ./terrraform
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        if: contains(github.event.pull_request.labels.*.name, 'ci-check/terraform') && github.event_name == 'pull_request'
+        working-directory: ./terrraform
+        run: terraform plan -no-color
+        continue-on-error: true
+
+      - uses: actions/github-script@0.9.0
+        if: github.event_name == 'pull_request'
+        working-directory: ./terrraform
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+            <details><summary>Show Plan</summary>
+
+            \`\`\`${process.env.PLAN}\`\`\`
+
+            </details>
+
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+      - name: Terraform Plan Status
+        working-directory: ./terrraform
+        if: contains(github.event.pull_request.labels.*.name, 'ci-check/terraform') && steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        working-directory: ./terrraform
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        run: terraform apply -auto-approve

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,5 @@ terraform {
 }
 
 provider "github" {
-  token        = var.github_token
   organization = "tinkerbell"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,13 +8,7 @@ terraform {
   }
 }
 
-variable "github_token" {
-  description = "GitHub token"
-  type        = string
-}
-
 provider "github" {
   token        = var.github_token
   organization = "tinkerbell"
 }
-

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "remote" {
+    organization = "tinkerbell"
+
+    workspaces {
+      name = "github_management"
+    }
+  }
+}
+
+variable "github_token" {
+  description = "GitHub token"
+  type        = string
+}
+
+provider "github" {
+  token        = var.github_token
+  organization = "tinkerbell"
+}
+

--- a/terraform/members.tf
+++ b/terraform/members.tf
@@ -1,0 +1,171 @@
+resource "github_membership" "amenowanna" {
+    username = "amenowanna"
+    role = "admin"
+}
+resource "github_membership" "benr" {
+    username = "benr"
+    role = "admin"
+}
+resource "github_membership" "bobfraser1" {
+    username = "bobfraser1"
+}
+resource "github_membership" "Cbkhare" {
+    username = "Cbkhare"
+}
+resource "github_membership" "DailyAlice" {
+    username = "DailyAlice"
+    role = "admin"
+}
+resource "github_membership" "DavidHwu" {
+    username = "DavidHwu"
+    role = "admin"
+}
+resource "github_membership" "detiber" {
+    username = "detiber"
+}
+resource "github_membership" "displague" {
+    username = "displague"
+    role = "admin"
+}
+resource "github_membership" "dizzyd" {
+    username = "dizzyd"
+}
+resource "github_membership" "dlaube" {
+    username = "dlaube"
+    role = "admin"
+}
+resource "github_membership" "dustinmiller1337" {
+    username = "dustinmiller1337"
+    role = "admin"
+}
+resource "github_membership" "felixwidjaja" {
+    username = "felixwidjaja"
+}
+resource "github_membership" "gauravgahlot" {
+    username = "gauravgahlot"
+}
+resource "github_membership" "geriadam" {
+    username = "geriadam"
+}
+resource "github_membership" "gianarb" {
+    username = "gianarb"
+    role = "admin"
+}
+resource "github_membership" "grahamc" {
+    username = "grahamc"
+    role = "admin"
+}
+resource "github_membership" "iaguis" {
+    username = "iaguis"
+}
+resource "github_membership" "invidian" {
+    username = "invidian"
+}
+resource "github_membership" "jacobsmith928" {
+    username = "jacobsmith928"
+    role = "admin"
+}
+resource "github_membership" "jacobweinstock" {
+    username = "jacobweinstock"
+    role = "admin"
+}
+resource "github_membership" "jeremytanner" {
+    username = "jeremytanner"
+}
+resource "github_membership" "jgavinray" {
+    username = "jgavinray"
+    role = "admin"
+}
+resource "github_membership" "jonawong" {
+    username = "jonawong"
+}
+resource "github_membership" "kdeng3849" {
+    username = "kdeng3849"
+    role = "admin"
+}
+resource "github_membership" "markyjackson-taulia" {
+    username = "markyjackson-taulia"
+}
+resource "github_membership" "matoszz" {
+    username = "matoszz"
+    role = "admin"
+}
+resource "github_membership" "mikemrm" {
+    username = "mikemrm"
+    role = "admin"
+}
+resource "github_membership" "mmlb" {
+    username = "mmlb"
+    role = "admin"
+}
+resource "github_membership" "mrmrcoleman" {
+    username = "mrmrcoleman"
+    role = "admin"
+}
+resource "github_membership" "nathangoulding" {
+    username = "nathangoulding"
+    role = "admin"
+}
+resource "github_membership" "packetbot" {
+    username = "packetbot"
+    role = "admin"
+}
+resource "github_membership" "parauliya" {
+    username = "parauliya"
+}
+resource "github_membership" "patrickdevivo" {
+    username = "patrickdevivo"
+    role = "admin"
+}
+resource "github_membership" "pereztr5" {
+    username = "pereztr5"
+    role = "admin"
+}
+resource "github_membership" "rainleander" {
+    username = "rainleander"
+    role = "admin"
+}
+resource "github_membership" "rawkode" {
+    username = "rawkode"
+}
+resource "github_membership" "ronggur" {
+    username = "ronggur"
+}
+resource "github_membership" "ScottGarman" {
+    username = "ScottGarman"
+    role = "admin"
+}
+resource "github_membership" "splaspood" {
+    role = "admin"
+    username = "splaspood"
+}
+resource "github_membership" "thebsdbox" {
+    username = "thebsdbox"
+}
+resource "github_membership" "thomcrowe" {
+    role = "admin"
+    username = "thomcrowe"
+}
+resource "github_membership" "tinkerbot" {
+    username = "tinkerbot"
+    role = "admin"
+}
+resource "github_membership" "tmurch-packet" {
+    username = "tmurch-packet"
+}
+resource "github_membership" "vielmetti" {
+    username = "vielmetti"
+    role = "admin"
+}
+resource "github_membership" "vishal-biyani" {
+    username = "vishal-biyani"
+}
+resource "github_membership" "wangxin311" {
+    username = "wangxin311"
+}
+resource "github_membership" "yetang-equinix" {
+    username = "yetang-equinix"
+}
+resource "github_membership" "zevweiss" {
+    username = "zevweiss"
+}

--- a/terraform/members.tf
+++ b/terraform/members.tf
@@ -1,171 +1,171 @@
 resource "github_membership" "amenowanna" {
-    username = "amenowanna"
-    role = "admin"
+  username = "amenowanna"
+  role     = "admin"
 }
 resource "github_membership" "benr" {
-    username = "benr"
-    role = "admin"
+  username = "benr"
+  role     = "admin"
 }
 resource "github_membership" "bobfraser1" {
-    username = "bobfraser1"
+  username = "bobfraser1"
 }
 resource "github_membership" "Cbkhare" {
-    username = "Cbkhare"
+  username = "Cbkhare"
 }
 resource "github_membership" "DailyAlice" {
-    username = "DailyAlice"
-    role = "admin"
+  username = "DailyAlice"
+  role     = "admin"
 }
 resource "github_membership" "DavidHwu" {
-    username = "DavidHwu"
-    role = "admin"
+  username = "DavidHwu"
+  role     = "admin"
 }
 resource "github_membership" "detiber" {
-    username = "detiber"
+  username = "detiber"
 }
 resource "github_membership" "displague" {
-    username = "displague"
-    role = "admin"
+  username = "displague"
+  role     = "admin"
 }
 resource "github_membership" "dizzyd" {
-    username = "dizzyd"
+  username = "dizzyd"
 }
 resource "github_membership" "dlaube" {
-    username = "dlaube"
-    role = "admin"
+  username = "dlaube"
+  role     = "admin"
 }
 resource "github_membership" "dustinmiller1337" {
-    username = "dustinmiller1337"
-    role = "admin"
+  username = "dustinmiller1337"
+  role     = "admin"
 }
 resource "github_membership" "felixwidjaja" {
-    username = "felixwidjaja"
+  username = "felixwidjaja"
 }
 resource "github_membership" "gauravgahlot" {
-    username = "gauravgahlot"
+  username = "gauravgahlot"
 }
 resource "github_membership" "geriadam" {
-    username = "geriadam"
+  username = "geriadam"
 }
 resource "github_membership" "gianarb" {
-    username = "gianarb"
-    role = "admin"
+  username = "gianarb"
+  role     = "admin"
 }
 resource "github_membership" "grahamc" {
-    username = "grahamc"
-    role = "admin"
+  username = "grahamc"
+  role     = "admin"
 }
 resource "github_membership" "iaguis" {
-    username = "iaguis"
+  username = "iaguis"
 }
 resource "github_membership" "invidian" {
-    username = "invidian"
+  username = "invidian"
 }
 resource "github_membership" "jacobsmith928" {
-    username = "jacobsmith928"
-    role = "admin"
+  username = "jacobsmith928"
+  role     = "admin"
 }
 resource "github_membership" "jacobweinstock" {
-    username = "jacobweinstock"
-    role = "admin"
+  username = "jacobweinstock"
+  role     = "admin"
 }
 resource "github_membership" "jeremytanner" {
-    username = "jeremytanner"
+  username = "jeremytanner"
 }
 resource "github_membership" "jgavinray" {
-    username = "jgavinray"
-    role = "admin"
+  username = "jgavinray"
+  role     = "admin"
 }
 resource "github_membership" "jonawong" {
-    username = "jonawong"
+  username = "jonawong"
 }
 resource "github_membership" "kdeng3849" {
-    username = "kdeng3849"
-    role = "admin"
+  username = "kdeng3849"
+  role     = "admin"
 }
 resource "github_membership" "markyjackson-taulia" {
-    username = "markyjackson-taulia"
+  username = "markyjackson-taulia"
 }
 resource "github_membership" "matoszz" {
-    username = "matoszz"
-    role = "admin"
+  username = "matoszz"
+  role     = "admin"
 }
 resource "github_membership" "mikemrm" {
-    username = "mikemrm"
-    role = "admin"
+  username = "mikemrm"
+  role     = "admin"
 }
 resource "github_membership" "mmlb" {
-    username = "mmlb"
-    role = "admin"
+  username = "mmlb"
+  role     = "admin"
 }
 resource "github_membership" "mrmrcoleman" {
-    username = "mrmrcoleman"
-    role = "admin"
+  username = "mrmrcoleman"
+  role     = "admin"
 }
 resource "github_membership" "nathangoulding" {
-    username = "nathangoulding"
-    role = "admin"
+  username = "nathangoulding"
+  role     = "admin"
 }
 resource "github_membership" "packetbot" {
-    username = "packetbot"
-    role = "admin"
+  username = "packetbot"
+  role     = "admin"
 }
 resource "github_membership" "parauliya" {
-    username = "parauliya"
+  username = "parauliya"
 }
 resource "github_membership" "patrickdevivo" {
-    username = "patrickdevivo"
-    role = "admin"
+  username = "patrickdevivo"
+  role     = "admin"
 }
 resource "github_membership" "pereztr5" {
-    username = "pereztr5"
-    role = "admin"
+  username = "pereztr5"
+  role     = "admin"
 }
 resource "github_membership" "rainleander" {
-    username = "rainleander"
-    role = "admin"
+  username = "rainleander"
+  role     = "admin"
 }
 resource "github_membership" "rawkode" {
-    username = "rawkode"
+  username = "rawkode"
 }
 resource "github_membership" "ronggur" {
-    username = "ronggur"
+  username = "ronggur"
 }
 resource "github_membership" "ScottGarman" {
-    username = "ScottGarman"
-    role = "admin"
+  username = "ScottGarman"
+  role     = "admin"
 }
 resource "github_membership" "splaspood" {
-    role = "admin"
-    username = "splaspood"
+  role     = "admin"
+  username = "splaspood"
 }
 resource "github_membership" "thebsdbox" {
-    username = "thebsdbox"
+  username = "thebsdbox"
 }
 resource "github_membership" "thomcrowe" {
-    role = "admin"
-    username = "thomcrowe"
+  role     = "admin"
+  username = "thomcrowe"
 }
 resource "github_membership" "tinkerbot" {
-    username = "tinkerbot"
-    role = "admin"
+  username = "tinkerbot"
+  role     = "admin"
 }
 resource "github_membership" "tmurch-packet" {
-    username = "tmurch-packet"
+  username = "tmurch-packet"
 }
 resource "github_membership" "vielmetti" {
-    username = "vielmetti"
-    role = "admin"
+  username = "vielmetti"
+  role     = "admin"
 }
 resource "github_membership" "vishal-biyani" {
-    username = "vishal-biyani"
+  username = "vishal-biyani"
 }
 resource "github_membership" "wangxin311" {
-    username = "wangxin311"
+  username = "wangxin311"
 }
 resource "github_membership" "yetang-equinix" {
-    username = "yetang-equinix"
+  username = "yetang-equinix"
 }
 resource "github_membership" "zevweiss" {
-    username = "zevweiss"
+  username = "zevweiss"
 }

--- a/terraform/repo_team_permission.tf
+++ b/terraform/repo_team_permission.tf
@@ -1,0 +1,153 @@
+resource "github_team_repository" "infracloud_tink" {
+  team_id    = github_team.Infracloud.id
+  permission = "maintain"
+  repository = "tink"
+}
+resource "github_team_repository" "infracloud_tinkerbell_org" {
+  team_id    = github_team.Infracloud.id
+  permission = "maintain"
+  repository = "tinkerbell.org"
+}
+resource "github_team_repository" "infracloud_boots" {
+  team_id    = github_team.Infracloud.id
+  permission = "maintain"
+  repository = "boots"
+}
+resource "github_team_repository" "infracloud_hegel" {
+  team_id    = github_team.Infracloud.id
+  permission = "maintain"
+  repository = "hegel"
+}
+resource "github_team_repository" "infracloud_osie_og" {
+  team_id    = github_team.Infracloud.id
+  permission = "maintain"
+  repository = "osie-og"
+}
+resource "github_team_repository" "infracloud_osie" {
+  team_id    = github_team.Infracloud.id
+  permission = "maintain"
+  repository = "osie"
+}
+resource "github_team_repository" "infracloud_portal" {
+  team_id    = github_team.Infracloud.id
+  permission = "pull"
+  repository = "portal"
+}
+resource "github_team_repository" "infracloud_pbnj" {
+  team_id    = github_team.Infracloud.id
+  permission = "maintain"
+  repository = "pbnj"
+}
+resource "github_team_repository" "infracloud_github" {
+  team_id    = github_team.Infracloud.id
+  permission = "maintain"
+  repository = ".github"
+}
+resource "github_team_repository" "infracloud_tinkerbell_docs" {
+  team_id    = github_team.Infracloud.id
+  permission = "push"
+  repository = "tinkerbell-docs"
+}
+resource "github_team_repository" "infracloud_crossplane_provider_tinkerbell" {
+  team_id    = github_team.Infracloud.id
+  permission = "pull"
+  repository = "crossplane-provider-tinkerbell"
+}
+
+
+# Site Eng
+
+resource "github_team_repository" "site_eng_tink" {
+  team_id    = github_team.site-eng.id
+  permission = "admin"
+  repository = "tink"
+}
+resource "github_team_repository" "site_eng_boots" {
+  team_id    = github_team.site-eng.id
+  permission = "admin"
+  repository = "boots"
+}
+resource "github_team_repository" "site_eng_hegel" {
+  team_id    = github_team.site-eng.id
+  permission = "admin"
+  repository = "hegel"
+}
+resource "github_team_repository" "site_eng_osie" {
+  team_id    = github_team.site-eng.id
+  permission = "admin"
+  repository = "osie"
+}
+resource "github_team_repository" "site_eng_tftp_go" {
+  team_id    = github_team.site-eng.id
+  permission = "admin"
+  repository = "tftp-go"
+}
+resource "github_team_repository" "site_eng_pbnj" {
+  team_id    = github_team.site-eng.id
+  permission = "admin"
+  repository = "pbnj"
+}
+resource "github_team_repository" "site_eng_github" {
+  team_id    = github_team.site-eng.id
+  permission = "admin"
+  repository = ".github"
+}
+resource "github_team_repository" "site_eng_crossplane_provider_tinkerbell" {
+  team_id    = github_team.site-eng.id
+  permission = "pull"
+  repository = "crossplane-provider-tinkerbell"
+}
+
+
+# DevRel
+
+resource "github_team_repository" "devrel_tink" {
+  team_id    = github_team.devrel.id
+  permission = "maintain"
+  repository = "tink"
+}
+resource "github_team_repository" "devrel_tinkerbell_org" {
+  team_id    = github_team.devrel.id
+  permission = "maintain"
+  repository = "tinkerbell.org"
+}
+resource "github_team_repository" "devrel_boots" {
+  team_id    = github_team.devrel.id
+  permission = "maintain"
+  repository = "boots"
+}
+resource "github_team_repository" "devrel_hegel" {
+  team_id    = github_team.devrel.id
+  permission = "maintain"
+  repository = "hegel"
+}
+resource "github_team_repository" "devrel_osie" {
+  team_id    = github_team.devrel.id
+  permission = "maintain"
+  repository = "osie"
+}
+resource "github_team_repository" "devrel_pbnj" {
+  team_id    = github_team.devrel.id
+  permission = "maintain"
+  repository = "pbnj"
+}
+resource "github_team_repository" "devrel_github" {
+  team_id    = github_team.devrel.id
+  permission = "maintain"
+  repository = ".github"
+}
+resource "github_team_repository" "devrel_tinkerbell_docs" {
+  team_id    = github_team.devrel.id
+  permission = "maintain"
+  repository = "tinkerbell-docs"
+}
+resource "github_team_repository" "devrel_crossplane_provider_tinkerbell" {
+  team_id    = github_team.devrel.id
+  permission = "pull"
+  repository = "crossplane-provider-tinkerbell"
+}
+resource "github_team_repository" "devrel_workflows" {
+  team_id    = github_team.devrel.id
+  permission = "admin"
+  repository = "workflows"
+}

--- a/terraform/teams.tf
+++ b/terraform/teams.tf
@@ -1,0 +1,14 @@
+resource "github_team" "site-eng" {
+    name    = "site-eng"
+    privacy = "closed"
+}
+
+resource "github_team" "Infracloud" {
+    name    = "Infracloud"
+    privacy = "closed"
+}
+
+resource "github_team" "devrel" {
+    name    = "devrel"
+    privacy = "closed"
+}

--- a/terraform/teams.tf
+++ b/terraform/teams.tf
@@ -1,14 +1,14 @@
 resource "github_team" "site-eng" {
-    name    = "site-eng"
-    privacy = "closed"
+  name    = "site-eng"
+  privacy = "closed"
 }
 
 resource "github_team" "Infracloud" {
-    name    = "Infracloud"
-    privacy = "closed"
+  name    = "Infracloud"
+  privacy = "closed"
 }
 
 resource "github_team" "devrel" {
-    name    = "devrel"
-    privacy = "closed"
+  name    = "devrel"
+  privacy = "closed"
 }


### PR DESCRIPTION
## Description

This PR kicks out the work required to manage the Tinkerbell GitHub organization as code.
For now I would like to start syncing and managing:

- [x] membership
- [x] team
- [x] repository permissions

This PR needs CI/CD as well. The terraform state will be stored in Terraform Cloud, CI/CD will work via GitHub Aciton.

- [x] Setup CI/CD

NB: I have the state file locally, and `terraform plan` is in sync. I will move it to terraform soon but I think I need some help @mmlb @displague 

## Why is this needed

Managing the setting for this organization as code will decrease the chance for undocumented changes. Fewest people will have admin access and everything will have to happen as a pull request, with code review and so on.

As an open community and as members of CNCF we want to be as open as possible, and this is another step in that direction.