### PR TITLE
DO NOT MERGE: enable Terraform apply on CI merges

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -70,7 +70,6 @@ jobs:
       - name: Terraform Plan Status
         if: contains(github.event.pull_request.labels.*.name, 'ci-check/terraform') && steps.plan.outcome == 'failure'
         run: exit 1
-      # We will introduce it as soon as we validate a few PR and see what plan has to say!
-      #- name: Terraform Apply
-        #if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        #run: terraform apply -auto-approve
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        run: terraform apply -auto-approve


### PR DESCRIPTION
This branch and PR will also be used to verify the TF Plan once we add the `ci-check/terraform` tag.


Testing the CI/CD processes is hard 😅 

Now that the CI/CD pipeline is running when we expect it to, we need to confirm that the `plan` and eventual `apply` will do the right thing.

We should not merge this until the plan succeeds.
