### PR TITLE
Make CI/CD for GitHub management as code running for real

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -6,6 +6,7 @@ on:
       - 'terraform/**'
       - '.github/workflows/terraform.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform.yaml'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,3 +11,8 @@ terraform {
 provider "github" {
   organization = "tinkerbell"
 }
+
+variable "github_token" {
+  description = "GitHub token"
+  type        = string
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,7 @@ terraform {
 }
 
 provider "github" {
+  token        = var.github_token
   organization = "tinkerbell"
 }
 


### PR DESCRIPTION
## Description

Fix planning for Terraform and enable apply.

## Why is this needed

Currently, the CI/CD for managing GitHub org as code is halfway done. it does not run and we want to fix it.