### PR TITLE
Make CI/CD for GitHub management as code running for real

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -40,6 +40,8 @@ jobs:
         id: plan
         if: contains(github.event.pull_request.labels.*.name, 'ci-check/terraform') && github.event_name == 'pull_request'
         run: terraform plan -no-color
+        env:
+          TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
         continue-on-error: true
 
       - uses: actions/github-script@0.9.0
@@ -70,8 +72,12 @@ jobs:
 
       - name: Terraform Plan Status
         if: contains(github.event.pull_request.labels.*.name, 'ci-check/terraform') && steps.plan.outcome == 'failure'
+        env:
+          TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
         run: exit 1
       # We will introduce it as soon as we validate a few PR and see what plan has to say!
       #- name: Terraform Apply
         #if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        #env:
+          #TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
         #run: terraform apply -auto-approve

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -6,6 +6,7 @@ on:
       - 'terraform/**'
       - '.github/workflows/terraform.yaml'
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform.yaml'

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -75,9 +75,8 @@ jobs:
         env:
           TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
         run: exit 1
-      # We will introduce it as soon as we validate a few PR and see what plan has to say!
-      #- name: Terraform Apply
-        #if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        #env:
-          #TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
-        #run: terraform apply -auto-approve
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        env:
+          TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
+        run: terraform apply -auto-approve

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,3 +11,8 @@ terraform {
 provider "github" {
   organization = "tinkerbell"
 }
+
+variable "github_token" {
+  description = "GitHub token"
+  type        = string
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,7 @@ terraform {
 }
 
 provider "github" {
+  token        = var.github_token
   organization = "tinkerbell"
 }
 


### PR DESCRIPTION
## Description

Fix planning for Terraform and enable apply.

## Why is this needed

Currently, the CI/CD for managing GitHub org as code is halfway done. it does not run and we want to fix it.