### PR TITLE
Split terraform apply in its own workflow

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -2,14 +2,18 @@ name: "Terraform"
 
 on:
   push:
+    branches:
+      - 'master'
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform.yaml'
+      - '.github/workflows/terraform_apply.yaml'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform.yaml'
+      - '.github/workflows/terraform_apply.yaml'
 
 jobs:
   terraform:
@@ -75,8 +79,3 @@ jobs:
         env:
           TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
         run: exit 1
-      - name: Terraform Apply
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        env:
-          TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
-        run: terraform apply -auto-approve

--- a/.github/workflows/terraform_apply.yaml
+++ b/.github/workflows/terraform_apply.yaml
@@ -1,0 +1,40 @@
+name: "Terraform"
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yaml'
+      - '.github/workflows/terraform_apply.yaml'
+
+jobs:
+  terraform_apply:
+    defaults:
+      run:
+        working-directory: ./terraform
+    name: "Terraform Apply"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+      - name: Terraform Init
+        id: init
+        run: terraform init
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color
+        env:
+          TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
+      - name: Terraform Apply
+        env:
+          TF_VAR_github_token: ${{ secrets.TF_VAR_GITHUB_TOKEN }}
+        run: terraform apply -auto-approve


### PR DESCRIPTION
The Terraform workflow was getting a bit hard to code and test with too
many tasks to handle. It had to check for push, pull requests, look for
particular labels, send comments, and so on.

I decide to split the apply part in its own workflow because it sounds
easier to configure when it has to start, only for a push on the default
branch.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>