### PR TITLE
Decrease the number of members with admin access

### DIFF
--- a/terraform/members.tf
+++ b/terraform/members.tf
@@ -1,6 +1,5 @@
 resource "github_membership" "amenowanna" {
   username = "amenowanna"
-  role     = "admin"
 }
 resource "github_membership" "benr" {
   username = "benr"
@@ -22,29 +21,24 @@ resource "github_membership" "Cbkhare" {
 }
 resource "github_membership" "DailyAlice" {
   username = "DailyAlice"
-  role     = "admin"
 }
 resource "github_membership" "DavidHwu" {
   username = "DavidHwu"
-  role     = "admin"
 }
 resource "github_membership" "detiber" {
   username = "detiber"
 }
 resource "github_membership" "displague" {
   username = "displague"
-  role     = "admin"
 }
 resource "github_membership" "dizzyd" {
   username = "dizzyd"
 }
 resource "github_membership" "dlaube" {
   username = "dlaube"
-  role     = "admin"
 }
 resource "github_membership" "dustinmiller1337" {
   username = "dustinmiller1337"
-  role     = "admin"
 }
 resource "github_membership" "felixwidjaja" {
   username = "felixwidjaja"
@@ -61,7 +55,6 @@ resource "github_membership" "gianarb" {
 }
 resource "github_membership" "grahamc" {
   username = "grahamc"
-  role     = "admin"
 }
 resource "github_membership" "iaguis" {
   username = "iaguis"
@@ -71,36 +64,30 @@ resource "github_membership" "invidian" {
 }
 resource "github_membership" "jacobsmith928" {
   username = "jacobsmith928"
-  role     = "admin"
 }
 resource "github_membership" "jacobweinstock" {
   username = "jacobweinstock"
-  role     = "admin"
 }
 resource "github_membership" "jeremytanner" {
   username = "jeremytanner"
 }
 resource "github_membership" "jgavinray" {
   username = "jgavinray"
-  role     = "admin"
 }
 resource "github_membership" "jonawong" {
   username = "jonawong"
 }
 resource "github_membership" "kdeng3849" {
   username = "kdeng3849"
-  role     = "admin"
 }
 resource "github_membership" "markyjackson-taulia" {
   username = "markyjackson-taulia"
 }
 resource "github_membership" "matoszz" {
   username = "matoszz"
-  role     = "admin"
 }
 resource "github_membership" "mikemrm" {
   username = "mikemrm"
-  role     = "admin"
 }
 resource "github_membership" "mmlb" {
   username = "mmlb"
@@ -108,14 +95,9 @@ resource "github_membership" "mmlb" {
 }
 resource "github_membership" "mrmrcoleman" {
   username = "mrmrcoleman"
-  role     = "admin"
 }
 resource "github_membership" "nathangoulding" {
   username = "nathangoulding"
-  role     = "admin"
-}
-resource "github_membership" "packetbot" {
-  username = "packetbot"
   role     = "admin"
 }
 resource "github_membership" "parauliya" {
@@ -123,15 +105,12 @@ resource "github_membership" "parauliya" {
 }
 resource "github_membership" "patrickdevivo" {
   username = "patrickdevivo"
-  role     = "admin"
 }
 resource "github_membership" "pereztr5" {
   username = "pereztr5"
-  role     = "admin"
 }
 resource "github_membership" "rainleander" {
   username = "rainleander"
-  role     = "admin"
 }
 resource "github_membership" "rawkode" {
   username = "rawkode"
@@ -141,17 +120,14 @@ resource "github_membership" "ronggur" {
 }
 resource "github_membership" "ScottGarman" {
   username = "ScottGarman"
-  role     = "admin"
 }
 resource "github_membership" "splaspood" {
-  role     = "admin"
   username = "splaspood"
 }
 resource "github_membership" "thebsdbox" {
   username = "thebsdbox"
 }
 resource "github_membership" "thomcrowe" {
-  role     = "admin"
   username = "thomcrowe"
 }
 resource "github_membership" "tinkerbot" {
@@ -163,7 +139,6 @@ resource "github_membership" "tmurch-packet" {
 }
 resource "github_membership" "vielmetti" {
   username = "vielmetti"
-  role     = "admin"
 }
 resource "github_membership" "vishal-biyani" {
   username = "vishal-biyani"


### PR DESCRIPTION
Now that we have infra as code in place we need a way to remove fat
fingers manually editing members and teams. A good way is to decrease
the number of people with admin access. This also improves security and
accountability.