### PR TITLE
use for-each to simplify team permissions

### DIFF
--- a/terraform/repo_team_permission.tf
+++ b/terraform/repo_team_permission.tf
@@ -1,57 +1,27 @@
-resource "github_team_repository" "infracloud_tink" {
-  team_id    = github_team.Infracloud.id
-  permission = "maintain"
-  repository = "tink"
+variable "infracloud_repos" {
+  default = {
+    "maintain" = ["tink", "tinkerbell.org", "boots", "hegel", "osie", "osie-og", "pbnj"],
+    "pull"     = ["portal", "crossplane-provider-tinkerbell"],
+    "push"     = ["tinkerbell-docs"]
+  }
 }
-resource "github_team_repository" "infracloud_tinkerbell_org" {
-  team_id    = github_team.Infracloud.id
-  permission = "maintain"
-  repository = "tinkerbell.org"
+
+locals {
+  infracloud_list = flatten([
+    for permission, repositories in var.infracloud_repos : [
+      for repository in repostiories : {
+        permission = permission
+        repository = repository
+      }
+    ]
+  ])
 }
-resource "github_team_repository" "infracloud_boots" {
+
+resource "github_team_repository" "infracloud" {
   team_id    = github_team.Infracloud.id
-  permission = "maintain"
-  repository = "boots"
-}
-resource "github_team_repository" "infracloud_hegel" {
-  team_id    = github_team.Infracloud.id
-  permission = "maintain"
-  repository = "hegel"
-}
-resource "github_team_repository" "infracloud_osie_og" {
-  team_id    = github_team.Infracloud.id
-  permission = "maintain"
-  repository = "osie-og"
-}
-resource "github_team_repository" "infracloud_osie" {
-  team_id    = github_team.Infracloud.id
-  permission = "maintain"
-  repository = "osie"
-}
-resource "github_team_repository" "infracloud_portal" {
-  team_id    = github_team.Infracloud.id
-  permission = "pull"
-  repository = "portal"
-}
-resource "github_team_repository" "infracloud_pbnj" {
-  team_id    = github_team.Infracloud.id
-  permission = "maintain"
-  repository = "pbnj"
-}
-resource "github_team_repository" "infracloud_github" {
-  team_id    = github_team.Infracloud.id
-  permission = "maintain"
-  repository = ".github"
-}
-resource "github_team_repository" "infracloud_tinkerbell_docs" {
-  team_id    = github_team.Infracloud.id
-  permission = "push"
-  repository = "tinkerbell-docs"
-}
-resource "github_team_repository" "infracloud_crossplane_provider_tinkerbell" {
-  team_id    = github_team.Infracloud.id
-  permission = "pull"
-  repository = "crossplane-provider-tinkerbell"
+  for_each   = local.infracloud_list
+  permission = each.value.permission
+  repository = each.value.repository
 }
 
 


### PR DESCRIPTION
## Description

First attempt at #25
<!--- Please describe what this PR is going to change -->

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?

`terraform fmt`
`terraform validate`

I could not try `terraform plan` because I don't have the backend configured.
I've run into this problem on another project and I'm wondering if `backend` should not be included in the project so that others can test it with plans.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?


<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
