### PR TITLE
Added community membership form and associated label

### DIFF
--- a/.github/ISSUE_TEMPLATE/community_member_request.yaml
+++ b/.github/ISSUE_TEMPLATE/community_member_request.yaml
@@ -1,0 +1,72 @@
+name: Community Membership Request
+description: Officially join the Tinkerbell community
+title: "[Organization/member]: request for <alias>"
+labels: ["kind/organization"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your willingness to participate in the Tinkerbell community!
+  - id: github
+    type: input
+    attributes:
+      label: GitHub Username
+      placeholder: e.g. @example_user
+    validations:
+      required: true
+  - type: dropdown
+    id: Role
+    attributes:
+      label: Role
+      description: |
+        What role would you like to participate in? Please see the [community roles](https://github.com/tinkerbell/proposals/blob/main/proposals/0024/GOVERNANCE.md#community-roles) for responsibilities and requirements of the various roles
+      options:
+        - Member
+        - Committer
+        - Maintainer
+    validations:
+      required: true
+  - id: requirements
+    type: checkboxes
+    attributes:
+      label: Requirements
+      description: Please ensure you meet the following criteria
+      options:
+      - label: I have reviewed the [community membership guidelines](https://github.com/tinkerbell/proposals/blob/main/proposals/0024/GOVERNANCE.md)
+        required: true
+      - label: I have [enabled 2FA on my GitHub account](https://github.com/settings/security)
+        required: true
+      - label: I have subscribed to the [tinkerbell-contributors e-mail list](https://groups.google.com/g/tinkerbell-contributors)
+        required: true
+      - label: I am actively contributing to 1 or more Tinkerbell subprojects
+        required: true
+      - label: I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
+        required: true
+      - label: I have spoken to my sponsors ahead of this application, and they have agreed to sponsor my application
+        required: true
+      - label: "**OPTIONAL:** I have taken the [Inclusive Open Source Community Orientation course](https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/)"
+  - id: sponsor_1
+    type: input
+    attributes:
+      label: "Sponsor 1"
+      description: GitHub handle of your sponsor
+      placeholder: e.g. @sponsor-1
+    validations:
+      required: true
+  - id: sponsor_2
+    type: input
+    attributes:
+      label: "Sponsor 2"
+      description: GitHub handle of your sponsor
+      placeholder: e.g. @sponsor-2
+    validations:
+      required: true
+  - id: contributions
+    type: textarea
+    attributes:
+      label: List of contributions to the Tinkerbell project
+      placeholder: |
+        - PRs reviewed / authored
+        - Issues responded to
+    validations:
+      required: true

--- a/labels/labels.yml
+++ b/labels/labels.yml
@@ -78,6 +78,10 @@ default:
       previously:
         - name: question
         - name: triage/support
+    - color: c7def8
+      description: Categorizes issue or PR as related to organization and governance.
+      name: kind/organization
+      target: both
 
    # well-known Github labels
     - color: 7057ff


### PR DESCRIPTION
Signed-off-by: Micah Hausler <mhausler@amazon.com>

## Description

Add a community membership form based on [K8s org membership](https://github.com/kubernetes/org/blob/main/.github/ISSUE_TEMPLATE/membership.yml)

## Why is this needed

The [current Governance form](https://github.com/tinkerbell/proposals/blob/main/proposals/0024/GOVERNANCE.md#requirements) links to Kubernetes. 

## Checklist:

I'll update the governance docs with a link to the issue template once this is merged