### PR TITLE
Create config.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## Description

Add ISSUE_TEMPLATE/config.yaml

## Why is this needed

When #36 was merged the old markdown based issue template was removed but github doesn't use the Bug Report template. Maybe because the config.yaml is missing? Lets find out.